### PR TITLE
fix: publish version if are in branch beta

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -49,8 +49,8 @@ jobs:
           git push --follow-tags origin beta
         fi
 
-      if: contains(github.ref, 'beta')
     - name: Publish beta version on NPM
+      if: contains(github.ref, 'beta')
       run: npm publish --access public --tag beta
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
fix verification of branch beta in bump-version workflow